### PR TITLE
Shorten package description to fit package.el conventions

### DIFF
--- a/latex-preview-pane-pkg.el
+++ b/latex-preview-pane-pkg.el
@@ -1,4 +1,4 @@
-(define-package "latex-preview-pane" "20140204" "Makes LaTeX editing less painful by providing a updatable preview pane. Full documentation can be found at: http://www.emacswiki.org/emacs/LaTeXPreviewPane" (quote nil))
+(define-package "latex-preview-pane" "20140204" "Makes LaTeX editing less painful by providing a updatable preview pane" (quote nil))
 
 
 


### PR DESCRIPTION
Hi! I'm adding latex-preview-pane to MELPA, and noticed that the package description is overly long. :-)
