### PR TITLE
Don't auto-enable the mode

### DIFF
--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -35,17 +35,17 @@
 ;;
 ;; You can find the documentation for latex-preview-pane either on GitHub (above) or on EmacsWiki at: http://www.emacswiki.org/emacs/LaTeXPreviewPane
 ;;
+;; To enable `latex-preview-pane-mode', use the following code:
+;;
+;;     (add-hook 'latex-mode-hook (lambda () (latex-preview-pane-mode t)))
+
+;;
 ;;; Code:
 
 
 ;;
 ;; Mode definition
 ;;
-
-;;; try to automatically load this when we open a .tex file
-;;;###autoload
-(add-hook 'latex-mode-hook (lambda () (latex-preview-pane-mode t)))
-
 
 
 (defun window-containing-preview () 


### PR DESCRIPTION
It's bad practice to enable modes automatically. Having code on his system doesn't imply that a user wants to enable it.

Packages should follow the same conventions as core emacs libraries, which are not all enabled by default. :-)
