### PR TITLE
Docview fixes

### DIFF
--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -302,10 +302,8 @@
     (if (file-exists-p pdf-filename)
         (if (eq (get-buffer pdf-buff) nil)
             (progn
-              (message "update-p: no buffer")
               (set-window-buffer (lpp/window-containing-preview) (find-file-noselect pdf-filename)))
 	    (progn
-          (message "update-p: buffer found")
 	      (set-window-buffer (lpp/window-containing-preview) pdf-buff) 
 	      (switch-to-buffer pdf-buff)
 	      (doc-view-revert-buffer nil t)

--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -301,8 +301,9 @@
     ;; if the file doesn't exist, say that the file isn't available due to error messages
     (if (file-exists-p pdf-filename)
         (if (eq (get-buffer pdf-buff-name) nil)
-            (progn
-              (set-window-buffer (lpp/window-containing-preview) (find-file-noselect pdf-filename)))
+            (let ((pdf-buff (find-file-noselect pdf-filename)))
+              (buffer-disable-undo pdf-buff)
+              (set-window-buffer (lpp/window-containing-preview) pdf-buff))
           (progn
             (set-window-buffer (lpp/window-containing-preview) pdf-buff-name) 
             (switch-to-buffer pdf-buff-name)

--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -296,20 +296,19 @@
   
   (let ((pdf-filename (replace-regexp-in-string "\.tex$" ".pdf" (lpp/buffer-file-name)))
 	(tex-buff (current-buffer))
-	(pdf-buff (replace-regexp-in-string "\.tex" ".pdf" (buffer-name (get-file-buffer (lpp/buffer-file-name))))))
+	(pdf-buff-name (replace-regexp-in-string "\.tex" ".pdf" (buffer-name (get-file-buffer (lpp/buffer-file-name))))))
     (remove-overlays)
     ;; if the file doesn't exist, say that the file isn't available due to error messages
     (if (file-exists-p pdf-filename)
-        (if (eq (get-buffer pdf-buff) nil)
+        (if (eq (get-buffer pdf-buff-name) nil)
             (progn
               (set-window-buffer (lpp/window-containing-preview) (find-file-noselect pdf-filename)))
-	    (progn
-	      (set-window-buffer (lpp/window-containing-preview) pdf-buff) 
-	      (switch-to-buffer pdf-buff)
-	      (doc-view-revert-buffer nil t)
-	      (switch-to-buffer tex-buff) 
-	      ))
-	
+          (progn
+            (set-window-buffer (lpp/window-containing-preview) pdf-buff-name) 
+            (switch-to-buffer pdf-buff-name)
+            (doc-view-revert-buffer nil t)
+            (switch-to-buffer tex-buff) 
+            ))
       ))))
 
 ;;


### PR DESCRIPTION
Fixes #41 . This is important fix because without it, each time PDF is updated the previous version is saved in UNDO buffer. Obviously, this takes a lot of memory, unnecessary.