### PR TITLE
Replace `switch-to-buffer` by `with-current-buffer`

### DIFF
--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -306,9 +306,7 @@
               (set-window-buffer (lpp/window-containing-preview) pdf-buff))
           (progn
             (set-window-buffer (lpp/window-containing-preview) pdf-buff-name) 
-            (switch-to-buffer pdf-buff-name)
-            (doc-view-revert-buffer nil t)
-            (switch-to-buffer tex-buff) 
+            (with-current-buffer pdf-buff-name (doc-view-revert-buffer nil t))
             ))
       ))))
 

--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -301,7 +301,7 @@
     ;; if the file doesn't exist, say that the file isn't available due to error messages
     (if (file-exists-p pdf-filename)
         (if (eq (get-buffer pdf-buff-name) nil)
-            (let ((pdf-buff (find-file-noselect pdf-filename)))
+            (let ((pdf-buff (find-file-noselect pdf-filename 'nowarn)))
               (buffer-disable-undo pdf-buff)
               (set-window-buffer (lpp/window-containing-preview) pdf-buff))
           (progn


### PR DESCRIPTION
This avoids some problems with preserving the the window point in the TeX buffer.

With Spacemacs in develop branch on Emacs 25, the window point of the buffer always ended up in the same location of the document, which made latex-preview-pane completely unusable.

I have been using this change for a few days now, and have not noticed any change, except to that LaTeX buffer's point doesn't change when updating the preview pane.