### PR TITLE
Option to compile with SyncTeX using a new custom variable

### DIFF
--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -46,7 +46,7 @@
 (require 'doc-view)
 (require 'cl-lib)
 
-(defvar latex-preview-pane-current-version "20151021")
+(defvar latex-preview-pane-current-version "20210417")
 ;;
 ;; Get rid of free variables warnings
 ;;
@@ -277,11 +277,10 @@
 
 (defun lpp/invoke-pdf-latex-command ()
   (let ((buff (expand-file-name (lpp/buffer-file-name))) (default-directory (file-name-directory (expand-file-name (lpp/buffer-file-name)))))
-    (if shell-escape-mode
-	(call-process pdf-latex-command nil "*pdflatex-buffer*" nil shell-escape-mode buff)
-      (call-process pdf-latex-command nil "*pdflatex-buffer*" nil buff)
-      )
-    )
+    (if (string-match pdf-latex-command "luatex")  ;; long flags in luatex require -- (man luatex)
+        (call-process pdf-latex-command nil "*pdflatex-buffer*" nil (concat "--synctex=" synctex-number " -" shell-escape-mode) buff)
+        (call-process pdf-latex-command nil "*pdflatex-buffer*" nil (concat "-synctex=" synctex-number " " shell-escape-mode) buff)
+      ))
   )
 
 
@@ -390,8 +389,23 @@
   :type 'string
   :group 'latex-preview-pane)
 
+
+(defcustom synctex-number "0"
+  "Should the pdf-latex-command command run with SyncTeX?"
+  :type '(choice (const :tag "Run without SyncTeX" "0")
+                 (const :tag "SyncTeX files are text files" "-1")
+                 (const :tag "SyncTeX files are compressed with gz (Standard)" "1")
+                 (const :tag "No .gz extension is used" "2")
+                 (const :tag "Activate form support, useful for pdftex" "4")
+                 (const :tag "Better file compression" "8")
+                 (const :tag "Everything" "15")
+                 (string :tag "Other values")
+                 )
+  :group 'latex-preview-pane)
+
+
 (defcustom shell-escape-mode nil
-  "Should the pdflatex command use shell escaping?"
+  "Should the pdf-latex-command command use shell escaping?"
   :type '(choice (const :tag "Use shell escaping (-shell-escape)" "-shell-escape")
                  (const :tag "Do not use shell escaping" nil)
                  )

--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -302,10 +302,12 @@
         (if (eq (get-buffer pdf-buff-name) nil)
             (let ((pdf-buff (find-file-noselect pdf-filename 'nowarn)))
               (buffer-disable-undo pdf-buff)
-              (set-window-buffer (lpp/window-containing-preview) pdf-buff))
+              (set-window-buffer (lpp/window-containing-preview) pdf-buff)
+              (TeX-pdf-tools-sync-view))
           (progn
             (set-window-buffer (lpp/window-containing-preview) pdf-buff-name) 
             (with-current-buffer pdf-buff-name (doc-view-revert-buffer nil t))
+            (TeX-pdf-tools-sync-view)
             ))
       ))))
 


### PR DESCRIPTION
This PR is to solve #20 and #28 

Instead of forcing the compiler to compile with SyncTeX, I introduced a new custom variable that users can tweak in their _.emacs_ configuration or through the easy customization prompt in Emacs to tell the compiler whether SyncTeX should be used. 

The second commit ties in pdf-sync from pdf-tool to follow the cursor position.