### PR TITLE
fix lpp/window-containing-preview

### DIFF
--- a/latex-preview-pane.el
+++ b/latex-preview-pane.el
@@ -60,18 +60,8 @@
    (add-hook 'latex-mode-hook (lambda () (latex-preview-pane-mode 1))))
 
 (defun lpp/window-containing-preview ()
-  (let (windows i docViewWindow)
-    (setq windows (cl-reduce #'append (mapcar `window-list (frame-list))))
-    (setq i 0)
-    (progn
-    (while (and (not docViewWindow) (<= i (length windows)))
-      (let ((currentWindow (pop windows)))
-	(if (window-parameter currentWindow 'is-latex-preview-pane)
-	    (setq docViewWindow currentWindow)
-	  ))
-      (setq i (1+ i))
-      )
-    docViewWindow)))
+  (let ((windows (cl-reduce #'append (mapcar `window-list (frame-list)))))
+    (cl-find-if (lambda (window) (window-parameter window 'is-latex-preview-pane)) windows)))
 
 ;;
 ;; Init procedure:


### PR DESCRIPTION
This is to fix a bug where the latex-preview-pane sometimes fail to find the correct window containing preview when there is more than 3 windows (across multiple frames). The cause of this bug is that the length of `windows` on line 67 is dynamical so the function misses the body of list. I have re-implemented the function using `cl-find`. Hopefully this makes the code more readable while maintaining the same functionality. 